### PR TITLE
Support for controllerAs syntax

### DIFF
--- a/build/ng-textarea-enter.min.js
+++ b/build/ng-textarea-enter.min.js
@@ -4,4 +4,4 @@
     Licence: MIT
     Demo on CodePen - http://codepen.io/amdsouza92/pen/pyNMjQ
 */
-"use strict";angular.module("ngTextareaEnter",[]).directive("ngTextareaEnter",function(){return{restrict:"A",link:function(a,b,c){b.bind("keydown",function(d){var e=d.keyCode||d.which;13===e&&"textarea"==b[0].type&&void 0!=a[c.ngModel]&&""!=a[c.ngModel]&&(d.shiftKey||d.ctrlKey||d.altKey||(d.preventDefault(),a.$apply(c.ngTextareaEnter)))})}}});
+"use strict";angular.module("ngTextareaEnter",[]).directive("ngTextareaEnter",function(){return{restrict:"A",link:function(a,b,c){b.bind("keydown",function(d){function e(a,b,c){var d,e;for(d=0,b=b.split("."),e=b.length;d<e;d++){if(!a||"object"!=typeof a)return c;a=a[b[d]]}return void 0===a?c:a}var f=d.keyCode||d.which;if(13===f&&"textarea"==b[0].type){var g=e(a,c.ngModel);void 0!==g&&""!==g&&(d.shiftKey||d.ctrlKey||d.altKey||(d.preventDefault(),a.$apply(c.ngTextareaEnter)))}})}}});

--- a/src/ng-textarea-enter.js
+++ b/src/ng-textarea-enter.js
@@ -12,26 +12,48 @@ angular.module('ngTextareaEnter', []).directive('ngTextareaEnter', function() {
 
 			// Detecting key down event
 			elem.bind('keydown', function(event) {
-		    	var code = event.keyCode || event.which;
+				
+				var code = event.keyCode || event.which;
 
-		    	// Detecting enter key press
-		       	if (code === 13) {
+				// Detecting enter key press
+				if (code === 13) {
 
-		       		// Checking element to be textarea
-		       		if(elem[0].type == 'textarea') {
+					// Checking element to be textarea
+					if(elem[0].type == 'textarea') {
 
-		       			// Checking scope model to be valid
-		       			if(scope[attrs.ngModel] != undefined && scope[attrs.ngModel] != '') {
+						// used to get path for controllerAs syntax
+						function path(obj, path, def) {
+								var i, len;
 
-		       				// Detecting shift/ctrl/alt key press
-				       		if (!event.shiftKey && !event.ctrlKey && !event.altKey) {
-				           		event.preventDefault();
-				               	scope.$apply(attrs.ngTextareaEnter);
-				            }
-		       			}
-		       		}
-		       	}
-		    });
+								for(i = 0,path = path.split('.'), len = path.length; i < len; i++) {
+										if(!obj || typeof obj !== 'object') return def;
+										obj = obj[path[i]];
+								}
+
+								if(obj === undefined) return def;
+								return obj;
+						}
+
+						// Determine scope model
+						var ngModel = path(scope, attrs.ngModel);
+
+						// Checking scope model to be valid
+						if(ngModel !== undefined && ngModel !== '') {
+
+							// Detecting shift/ctrl/alt key press
+							if (!event.shiftKey && !event.ctrlKey && !event.altKey) {
+								event.preventDefault();
+								scope.$apply(attrs.ngTextareaEnter);
+							}
+
+						}
+
+					}
+
+				}
+
+			});
+
 		}
 	}
 });


### PR DESCRIPTION
The original code assumes that ng-model does not contain a ‘.’ or does not use controllerAs syntax. This means using ng-model like vm.foo or $ctrl.foo will not work as it will search for scope[vm.foo] instead of scope.vm.foo. Using a path function inspired from lodash, dynamically retrieve value on scope with the given ng-model as the path.