### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To create usual newlines, a combination of ``shift+enter``, ``ctrl+enter`` and `
 Use ng-textarea-enter directly from jsdelivr CDN
 
 ```html
-https://cdn.jsdelivr.net/angular.textarea-enter/0.2.1/ng-textarea-enter.min.js
+https://cdn.jsdelivr.net/npm/ng-textarea-enter@0.2.1/build/ng-textarea-enter.min.js
 ```
 
 #### via bower


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/ng-textarea-enter.

Feel free to ping me if you have any questions regarding this change.